### PR TITLE
remove object files left over from creating vignettes

### DIFF
--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -145,4 +145,31 @@ R CMD build \
     --keep-empty-dirs \
     lightgbm_r
 
+echo "removing object files created by vignettes"
+mkdir _tmp
+mv lightgbm*.tar.gz _tmp/
+TARBALL_NAME=lightgbm_${LGB_VERSION}.tar.gz
+# cd _tmp
+#     # tar -xvf ${TARBALL_NAME}
+#     rm ${TARBALL_NAME}
+#     # find ./ -name \*.a -type f -exec rm -rf {} +
+#     # find ./ -name \*.dll -type f -exec rm -rf {} +
+#     # find ./ -name \*.o -type f -exec rm -rf {} +
+#     # find ./ -name \*.so -type f -exec rm -rf {} +
+# cd ..
+
+cd _tmp
+    tar \
+        -czvf ${TARBALL_NAME} \
+        --exclude=*.a \
+        --exclude=*.dll \
+        --exclude=*.o \
+        --exclude=*.so \
+        --exclude=*.tar.gz \
+        .
+    cp ${TARBALL_NAME} ../
+cd ..
+
+rm -rf ./_tmp
+
 echo "Done building R package"

--- a/build-cran-package.sh
+++ b/build-cran-package.sh
@@ -147,18 +147,12 @@ R CMD build \
 
 echo "removing object files created by vignettes"
 mkdir _tmp
-mv lightgbm*.tar.gz _tmp/
 TARBALL_NAME=lightgbm_${LGB_VERSION}.tar.gz
-# cd _tmp
-#     # tar -xvf ${TARBALL_NAME}
-#     rm ${TARBALL_NAME}
-#     # find ./ -name \*.a -type f -exec rm -rf {} +
-#     # find ./ -name \*.dll -type f -exec rm -rf {} +
-#     # find ./ -name \*.o -type f -exec rm -rf {} +
-#     # find ./ -name \*.so -type f -exec rm -rf {} +
-# cd ..
+mv ${TARBALL_NAME} _tmp/
 
 cd _tmp
+    tar -xvf ${TARBALL_NAME}
+    rm -rf ${TARBALL_NAME}
     tar \
         -czvf ${TARBALL_NAME} \
         --exclude=*.a \


### PR DESCRIPTION
This PR fixes some `R CMD check` issues introduced by adding vignettes to `{lightgbm}` (https://github.com/microsoft/LightGBM/pull/3946).